### PR TITLE
chore: :technologist: update VS Code extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,16 +1,16 @@
 {
-  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-  // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
-    "jebbs.plantuml",
+    "eamodio.gitlens",
+    "github.vscode-github-actions",
+    "redhat.vscode-yaml",
     "donjayamanne.githistory",
     "felipecaputo.git-project-manager",
     "GitHub.vscode-pull-request-github",
-    "quarto.quarto",
-    "streetsidesoftware.code-spell-checker",
     "vivaxy.vscode-conventional-commits",
-    "pshaddel.conventional-branch"
+    "quarto.quarto",
+    "pshaddel.conventional-branch",
+    "EditorConfig.EditorConfig",
+    "tekumara.typos-vscode",
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []


### PR DESCRIPTION
## Description

These extensions greatly simplify a lot of admin and other work. Of course, they only work in the editor VS Code.

Closes #41

## Checklist

- [x] Ran `just run-all`
