### PR TITLE
chore: :technologist: remove use of cSpell checker, use typos instead

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,27 +1,23 @@
 {
-    "files.autoSave": "onFocusChange",
-    "editor.wordWrap": "on",
-    "editor.formatOnSave": false,
-    "git.autofetch": false,
-    "quarto.visualEditor.markdownWrap": "column",
-    "quarto.visualEditor.markdownWrapColumn": 72,
-    "editor.tabCompletion": "on",
-    "editor.snippetSuggestions": "inline",
-    "conventional-branch.type": [
-        "build", // Changes that affect the build system or external dependencies
-        "ci", // Changes to our CI configuration files and scripts
-        "docs", // Documentation only changes
-        "feat", // A new feature
-        "fix", // A bug fix
-        "refactor", // A code change that neither fixes a bug nor adds a feature
-        "style", // Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-        "test", // Adding missing tests or correcting existing tests
-        "chore", // Misc things, like renaming or deleting files
-    ],
-    "conventional-branch.format": "{Type}/{Branch}",
-    "files.insertFinalNewline": true,
-    "cSpell.enabledFileTypes": {
-        "quarto": true
-    },
-    "cSpell.language": "en,en-GB",
+  "files.autoSave": "onFocusChange",
+  "editor.wordWrap": "off",
+  "editor.formatOnSave": false,
+  "git.autofetch": false,
+  "quarto.visualEditor.markdownWrap": "column",
+  "quarto.visualEditor.markdownWrapColumn": 72,
+  "editor.tabCompletion": "on",
+  "editor.snippetSuggestions": "inline",
+  "conventional-branch.type": [
+    "build", // Changes that affect the build system or external dependencies
+    "ci", // Changes to our CI configuration files and scripts
+    "docs", // Documentation only changes
+    "feat", // A new feature
+    "fix", // A bug fix
+    "refactor", // A code change that neither fixes a bug nor adds a feature
+    "style", // Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+    "test", // Adding missing tests or correcting existing tests
+    "chore", // Misc things, like renaming or deleting files
+  ],
+  "conventional-branch.format": "{Type}/{Branch}",
+  "files.insertFinalNewline": true,
 }


### PR DESCRIPTION
## Description

Don't need the extension cSpell, since the typos extension/cli works better.

Closes #40

## Checklist

- [x] Ran `just run-all`
