### PR TITLE
build: :wrench: add typos config file to ignore specific files

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,5 @@
+[files]
+extend-exclude = [
+  "*.css",
+  "*.svg"
+]


### PR DESCRIPTION
## Description

Don't need typos to check css and svg files. Lots of false positives there.

## Checklist

- [x] Ran `just run-all`
