### PR TITLE
ci: :construction_worker: add auto-release workflow

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,8 @@
+[tool.commitizen]
+version = "0.1.0"
+bump_message = "build(version): :bookmark: update version from $current_version to $new_version"
+version_schema = "semver"
+version_provider = "commitizen"
+update_changelog_on_bump = true
+# Don't regenerate the changelog on every update
+changelog_incremental = true

--- a/.github/workflows/release-project.yml
+++ b/.github/workflows/release-project.yml
@@ -1,0 +1,21 @@
+name: Release project
+
+on:
+  push:
+    branches:
+      - main
+
+# Limit token permissions for security
+permissions: read-all
+
+jobs:
+  release-package:
+    # This job outputs env variables `previous_version` and `current_version`.
+    # Only give permissions for this job.
+    permissions:
+      contents: write
+    uses: seedcase-project/.github/.github/workflows/reusable-release-project.yml@main
+    with:
+      app-id: ${{ vars.UPDATE_VERSION_APP_ID }}
+    secrets:
+      update-version-gh-token: ${{ secrets.UPDATE_VERSION_TOKEN }}


### PR DESCRIPTION
## Description

This workflow makes it so that specific commits (that follow Conventional Commit style) will increase the version of the repo and create a GitHub release. This will eventually be used to connect GitHub releases to Zenodo, so that every release will push to Zenodo.

Closes #42

## Checklist

- [x] Ran `just run-all`
