### PR TITLE
ci: :construction_worker: use Seedcase's workflow for sync security

### DIFF
--- a/.github/workflows/sync-files.yml
+++ b/.github/workflows/sync-files.yml
@@ -1,24 +1,18 @@
-name: Sync files across repos
+name: Sync with repos
+
 on:
   push:
     branches:
       - main
   workflow_dispatch:
 
+# Limit permissions to improve security.
+permissions: read-all
+
 jobs:
   sync:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Run GitHub File Sync
-        uses: BetaHuhn/repo-file-sync-action@v1
-        with:
-          GH_PAT: ${{ secrets.SYNC_PAT }}
-          ASSIGNEES: lwjohnst86
-          IS_FINE_GRAINED: true
-          GIT_USERNAME: lwjohnst86
-          GIT_EMAIL: lwjohnst@gmail.com
-          COMMIT_PREFIX: "chore(sync): :hammer: "
-          BRANCH_PREFIX: chore
+    uses: seedcase-project/.github/.github/workflows/reusable-sync-files.yml@main
+    with:
+      app-id: ${{ vars.SYNC_FILES_APP_ID }}
+    secrets:
+      sync-files-token: ${{ secrets.SYNC_FILES_TOKEN }}


### PR DESCRIPTION
## Description

There are some small security practices that we've built into with the Seedcase reusable workflow for the synching files between repos.

Closes #45

## Checklist

- [x] Ran `just run-all`
