### PR TITLE
ci: :lock: limit permissions for security

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -11,12 +11,15 @@ on:
       - reopened
       - opened
 
-permissions:
-  pull-requests: write
+# Improve security by limiting permissions.
+permissions: read-all
 
 jobs:
   add-to-project:
     uses: dp-next/.github/.github/workflows/reusable-add-to-project.yml@main
+    # Set at job level for where it is needed.
+    permissions:
+      pull-requests: write
     with:
       board-number: 9
     secrets:


### PR DESCRIPTION
## Description

Limits the default security of the `GITHUB_TOKEN`, to only set permissions as workflow level.

## Checklist

- [x] Ran `just run-all`
