### PR TITLE
fix: :pencil2: wrong paths to design files

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -36,10 +36,10 @@ book:
         - roadmap.qmd
     - part: Design
       chapters:
-        - index.qmd
-        - patterns.qmd
-        - practicals.qmd
-        - naming.qmd
+        - design/index.qmd
+        - design/patterns.qmd
+        - design/practicals.qmd
+        - design/naming.qmd
     - part: Decisions
       chapters:
         - decisions/index.qmd


### PR DESCRIPTION
# Description

Forgot to append with `design/`.

Needs no review.

## Checklist

- [x] Ran `just run-all`
